### PR TITLE
Support symbols for event collection names

### DIFF
--- a/lib/keen/client/querying_methods.rb
+++ b/lib/keen/client/querying_methods.rb
@@ -165,7 +165,7 @@ module Keen
         ensure_read_key!
 
         if event_collection
-          params[:event_collection] = event_collection
+          params[:event_collection] = event_collection.to_s
         end
 
         query_params = preprocess_params(params)

--- a/spec/keen/client/querying_methods_spec.rb
+++ b/spec/keen/client/querying_methods_spec.rb
@@ -113,12 +113,22 @@ describe Keen::Client do
   end
 
   describe "#count" do
-    it "should not require params" do
-      query_params = "?event_collection=#{event_collection}"
-      url = query_url("count", query_params)
+    let(:query_params) { "?event_collection=#{event_collection}" }
+    let(:url) { query_url("count", query_params) }
+    before do
       stub_keen_get(url, 200, :result => 10)
+    end
+
+    it "should not require params" do
       client.count(event_collection).should == 10
       expect_keen_get(url, "sync", read_key)
+    end
+
+    context "with event collection as symbol" do
+      let(:event_collection) { :users }
+      it "should not require a string" do
+        client.count(event_collection).should == 10
+      end
     end
   end
 


### PR DESCRIPTION
I kept wanting to write things like `Keen.count(:user_sign_in)` with the event collection name as a symbol instead of a string. It feels more natural in Ruby to me. So this commit supports that.
