### PR TITLE
Change README to suggest requiring em-http-request

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Next, run an instance of EventMachine. If you're using an EventMachine-based web
 thin or goliath you're already doing this. Otherwise, you'll need to start an EventMachine loop manually as follows:
 
 ```ruby
+require 'em-http-request'
+
 Thread.new { EventMachine.run }
 ```
 


### PR DESCRIPTION
Slight clarification of using async events:

``` ruby
require 'em-http-request'
```

I originally forgot to do this and got the predictable error:
Keen IO Exception: An EventMachine loop must be running to use
publish_async calls (Keen::Error)

I got this error even though the code had:

``` ruby
Thread.new { EventMachine.run }
```

The problem was that the error message related to missing EventMachine:
  NameError: uninitialized constant EventMachine

was being swallowed in the Thread.new call so it took me a little longer
than it should have to realize that I never required EventMachine or em-http-request.
