### PR TITLE
Fixed problem with parameter modified at QueryingMethods

### DIFF
--- a/lib/keen/client/querying_methods.rb
+++ b/lib/keen/client/querying_methods.rb
@@ -161,14 +161,15 @@ module Keen
       private
 
       def query(query_name, event_collection, params)
+        query_params = clone_params(params)
         ensure_project_id!
         ensure_read_key!
 
         if event_collection
-          params[:event_collection] = event_collection.to_s
+          query_params[:event_collection] = event_collection.to_s
         end
 
-        query_params = preprocess_params(params)
+        query_params = preprocess_params(query_params)
 
         begin
           response = Keen::HTTP::Sync.new(self.api_url, self.proxy_url).get(
@@ -180,6 +181,10 @@ module Keen
 
         response_body = response.body.chomp
         process_response(response.code, response_body)["result"]
+      end
+
+      def clone_params(params)
+        params.dup
       end
 
       def api_query_resource_path(analysis_type)

--- a/spec/keen/client/querying_methods_spec.rb
+++ b/spec/keen/client/querying_methods_spec.rb
@@ -119,6 +119,17 @@ describe Keen::Client do
         }.to raise_error(Keen::AuthenticationError)
         expect_keen_get(url, "sync", read_key)
       end
+
+      it "should not change the extra params" do
+        timeframe = {
+          :start => "2012-08-13T19:00Z+00:00",
+          :end => "2012-08-13T19:00Z+00:00",
+        }
+        timeframe_str =  CGI.escape(MultiJson.encode(timeframe))
+
+        test_query("&timeframe=#{timeframe_str}", options = {:timeframe => timeframe})
+        options.should eq({:timeframe => timeframe})
+      end
     end
   end
 


### PR DESCRIPTION
  Fixes #40 Keen query modifes options hash
### Overview

Most of the Query Method receive a params hash that should be added to the request. But, after query ended, the params have been modified(escape params and add others values).

**Example:**

``` ruby
 options = {timeframe: {start: "2014-03-3", end:"2014-04-03"}}
 Keen.count 'a', options
 puts options
 {:timeframe=>"{\"start\":\"2014-03-3\",\"end\":\"2014-04-03\"}", :event_collection=>"a"}
```
### Issue

References and values and values that are references [(explained here)](http://stackoverflow.com/questions/22827566/ruby-parameters-by-reference-or-by-value/22827949#22827949)
### Solution

Create a clone for params called `query_parmas` (according with the preprocess_params result)

New results:

``` ruby
 options = {timeframe: {start: "2014-03-3", end:"2014-04-03"}}
 Keen.count 'a', options
 puts options
 {timeframe: {start: "2014-03-3", end:"2014-04-03"}}
```
