### PR TITLE
Implementing feature 'Get list of collections for a given project' for issue #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ Many of there queries can be performed with group by, filters, series and interv
 
 Detailed information on available parameters for each API resource can be found on the [API Technical Reference](https://keen.io/docs/api/reference/).
 
+### Listing collections
+
+The Keen IO API let you get the event collections for the project set, it includes properties and their type. It also returns links to the collection resource.
+
+```ruby
+Keen.event_collections # => [{ "name": "purchases", "properties": { "item.id": "num", ... }, ... }]
+```
+
+Getting the list of event collections requires that the `KEEN_MASTER_KEY` is set.
+
 ### Deleting events
 
 The Keen IO API allows you to [delete events](https://keen.io/docs/maintenance/#deleting-event-collections)

--- a/lib/keen.rb
+++ b/lib/keen.rb
@@ -47,7 +47,8 @@ module Keen
                    :multi_analysis, :median, :percentile
 
     def_delegators :default_client,
-                   :delete
+                   :delete,
+                   :event_collections
 
     attr_writer :logger
 

--- a/lib/keen/client/maintenance_methods.rb
+++ b/lib/keen/client/maintenance_methods.rb
@@ -26,6 +26,26 @@ module Keen
         response_body = response.body ? response.body.chomp : ''
         process_response(response.code, response_body)
       end
+
+      # Runs an events query.
+      # See detailed documentation here:
+      # https://keen.io/docs/api/reference/#event-resource
+      def event_collections
+        ensure_project_id!
+        ensure_master_key!
+
+        begin
+          response = Keen::HTTP::Sync.new(self.api_url, self.proxy_url).get(
+              :path => "/#{api_version}/projects/#{project_id}/events",
+              :headers => api_headers(self.master_key, "sync"))
+        rescue Exception => http_error
+          raise HttpError.new("Couldn't perform events on Keen IO: #{http_error.message}", http_error)
+        end
+
+        response_body = response.body ? response.body.chomp : ''
+        process_response(response.code, response_body)
+      end
+
     end
   end
 end

--- a/spec/keen/client/maintenance_methods_spec.rb
+++ b/spec/keen/client/maintenance_methods_spec.rb
@@ -35,4 +35,14 @@ describe Keen::Client do
       expect_keen_delete(url, "sync", master_key)
     end
   end
+
+  describe '#event_collections' do
+    let(:events_url) { "#{api_url}/#{api_version}/projects/#{project_id}/events" }
+
+    it "should not require params" do
+      stub_keen_get(events_url, 200, [{ "a" => 1 }, { "b" => 2 }] )
+      client.event_collections.should == [{ "a" => 1 }, { "b" => 2 }]
+      expect_keen_get(events_url, "sync", master_key)
+    end
+  end
 end


### PR DESCRIPTION
## Feature

As a user I should be able to get the list of event collections for the project set.
## Implementation

As a reference you can take a look at the event resource https://keen.io/docs/api/reference/#event-resource

``` ruby
Keen.event_collections # => [{ "name": "purchases", "properties": { "item.id": "num", ... }, ... }]
```
