### PR TITLE
Expose the query method

### DIFF
--- a/lib/keen.rb
+++ b/lib/keen.rb
@@ -50,7 +50,8 @@ module Keen
                    :delete,
                    :event_collections,
                    :project_info,
-                   :query_url
+                   :query_url,
+                   :query
 
     attr_writer :logger
 


### PR DESCRIPTION
This PR exposes the `query` method, so it can be used with `Keen.query`
