### PR TITLE
Keen Timeout read config for feature #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Setting a master key is required for performing deletes. You can find keys for a
 on [keen.io](https://keen.io).
 
 The recommended way to set keys is via the environment. The keys you can set are 
-`KEEN_PROJECT_ID`, `KEEN_WRITE_KEY`, `KEEN_READ_KEY`, and `KEEN_MASTER_KEY`.
+`KEEN_PROJECT_ID`, `KEEN_WRITE_KEY`, `KEEN_READ_KEY`, `KEEN_MASTER_KEY`, `KEEN_READ_TIMEOUT`.
 You only need to specify the keys that correspond to the API calls you'll be performing. 
 If you're using [foreman](http://ddollar.github.com/foreman/), add this to your `.env` file:
 
@@ -40,6 +40,7 @@ If you're using [foreman](http://ddollar.github.com/foreman/), add this to your 
     KEEN_MASTER_KEY=xxxxxxxxxxxxxxx
     KEEN_WRITE_KEY=yyyyyyyyyyyyyyy
     KEEN_READ_KEY=zzzzzzzzzzzzzzz
+    KEEN_READ_TIMEOUT=60
 
 If not, make a script to export the variables into your shell or put it before the command you use to start your server.
 
@@ -266,6 +267,7 @@ Keen.project_id = 'xxxxxxxxxxxxxxx'
 Keen.write_key = 'yyyyyyyyyyyyyyy'
 Keen.read_key = 'zzzzzzzzzzzzzzz'
 Keen.master_key = 'aaaaaaaaaaaaaaa'
+Keen.read_timeoout = 60
 ```
 
 You can also configure unique client instances as follows:
@@ -274,7 +276,8 @@ You can also configure unique client instances as follows:
 keen = Keen::Client.new(:project_id => 'xxxxxxxxxxxxxxx',
                         :write_key  => 'yyyyyyyyyyyyyyy',
                         :read_key   => 'zzzzzzzzzzzzzzz',
-                        :master_key => 'aaaaaaaaaaaaaaa')
+                        :master_key => 'aaaaaaaaaaaaaaa',
+                        :read_timeout => 60)
 ```
 
 #### em-synchrony

--- a/lib/keen.rb
+++ b/lib/keen.rb
@@ -73,7 +73,8 @@ module Keen
         :master_key => ENV['KEEN_MASTER_KEY'],
         :api_url => ENV['KEEN_API_URL'],
         :proxy_url => ENV['KEEN_PROXY_URL'],
-        :proxy_type => ENV['KEEN_PROXY_TYPE']
+        :proxy_type => ENV['KEEN_PROXY_TYPE'],
+        :read_timeout => ENV['KEEN_READ_TIMEOUT']
       )
     end
   end

--- a/lib/keen/client.rb
+++ b/lib/keen/client.rb
@@ -15,7 +15,7 @@ module Keen
     include Keen::Client::QueryingMethods
     include Keen::Client::MaintenanceMethods
 
-    attr_accessor :project_id, :write_key, :read_key, :master_key, :api_url, :proxy_url, :proxy_type
+    attr_accessor :project_id, :write_key, :read_key, :master_key, :api_url, :proxy_url, :proxy_type, :read_timeout
 
     CONFIG = {
       :api_url => "https://api.keen.io",
@@ -49,6 +49,8 @@ module Keen
       self.api_url = options[:api_url] || CONFIG[:api_url]
 
       self.proxy_url, self.proxy_type = options.values_at(:proxy_url, :proxy_type)
+
+      self.read_timeout = options[:read_timeout].to_f unless options[:read_timeout].nil?
     end
 
     private

--- a/lib/keen/client/maintenance_methods.rb
+++ b/lib/keen/client/maintenance_methods.rb
@@ -68,7 +68,7 @@ module Keen
       private
 
       def http_sync
-        @http_sync ||= Keen::HTTP::Sync.new(self.api_url, self.proxy_url)
+        @http_sync ||= Keen::HTTP::Sync.new(self.api_url, self.proxy_url, self.read_timeout)
       end
 
     end

--- a/lib/keen/client/publishing_methods.rb
+++ b/lib/keen/client/publishing_methods.rb
@@ -161,7 +161,7 @@ module Keen
       def publish_body(path, body, error_method)
         begin
           response = Keen::HTTP::Sync.new(
-            self.api_url, self.proxy_url).post(
+            self.api_url, self.proxy_url, self.read_timeout).post(
               :path => path,
               :headers => api_headers(self.write_key, "sync"),
               :body => body)

--- a/lib/keen/client/querying_methods.rb
+++ b/lib/keen/client/querying_methods.rb
@@ -241,7 +241,7 @@ module Keen
 
       def get_response(url)
         uri = URI.parse(url)
-        Keen::HTTP::Sync.new(self.api_url, self.proxy_url).get(
+        Keen::HTTP::Sync.new(self.api_url, self.proxy_url, self.read_timeout).get(
           :path => "#{uri.path}?#{uri.query}",
           :headers => api_headers(self.read_key, "sync")
         )

--- a/lib/keen/http.rb
+++ b/lib/keen/http.rb
@@ -1,7 +1,7 @@
 module Keen
   module HTTP
     class Sync
-      def initialize(base_url, proxy_url=nil)
+      def initialize(base_url, proxy_url=nil, read_timeout=nil)
         require 'uri'
         require 'net/http'
 
@@ -10,6 +10,7 @@ module Keen
         arguments+= proxy_arguments_for(proxy_url) if proxy_url
 
         @http = Net::HTTP.new(*arguments)
+        @http.read_timeout = read_timeout if read_timeout
 
         if uri.scheme == "https"
           require 'net/https'

--- a/spec/keen/client_spec.rb
+++ b/spec/keen/client_spec.rb
@@ -6,12 +6,14 @@ describe Keen::Client do
   let(:read_key) { "abcderead" }
   let(:api_url) { "http://fake.keen.io:fakeport" }
   let(:client) { Keen::Client.new(:project_id => project_id) }
+  let(:read_timeout) { 40 }
 
   before do
     ENV["KEEN_PROJECT_ID"] = nil
     ENV["KEEN_WRITE_KEY"] = nil
     ENV["KEEN_READ_KEY"] = nil
     ENV["KEEN_API_URL"] = nil
+    ENV["KEEN_READ_TIMEOUT"] = nil
   end
 
   describe "#initialize" do
@@ -29,11 +31,13 @@ describe Keen::Client do
         :project_id => project_id,
         :write_key => write_key,
         :read_key => read_key,
-        :api_url => api_url)
+        :api_url => api_url,
+        :read_timeout => read_timeout)
       client.write_key.should == write_key
       client.read_key.should == read_key
       client.project_id.should == project_id
       client.api_url.should == api_url
+      client.read_timeout.should == read_timeout
     end
 
     it "should set a default api_url" do


### PR DESCRIPTION
### Requirement

Make the Net::HTTP read_timeout configurable
### Solution

Add **KEEN_READ_TIMEOUT** when Keen:Client  is created
