### PR TITLE
Fix publication when http proxy was set

### DIFF
--- a/lib/keen/http.rb
+++ b/lib/keen/http.rb
@@ -22,7 +22,7 @@ module Keen
       end
 
       def proxy_arguments_for(uri)
-        proxy_uri = URI.parse(proxy_url)
+        proxy_uri = URI.parse(uri)
         [proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password]
       end
 

--- a/spec/keen/client/publishing_methods_spec.rb
+++ b/spec/keen/client/publishing_methods_spec.rb
@@ -71,6 +71,22 @@ describe Keen::Client::PublishingMethods do
         ).publish(collection, event_properties)
       }.to raise_error(Keen::ConfigurationError, "Keen IO Exception: Write Key must be set for this operation")
     end
+
+    context "when using proxy" do
+      let(:client) do
+        Keen::Client.new(:project_id => project_id,
+                         :write_key => write_key,
+                         :api_url => api_url,
+                         :proxy_url => "http://localhost:8888",
+                         :proxy_type => "socks5")
+      end
+
+      it "should return the proper response" do
+        api_response = { "created" => true }
+        stub_keen_post(api_event_collection_resource_url(api_url, collection), 201, api_response)
+        client.publish(collection, event_properties).should == api_response
+      end
+    end
   end
 
   describe "publish_batch" do


### PR DESCRIPTION
This PR fixes the following error when you try to set a proxy on keen client:
`<Keen::HttpError: Keen IO Exception: HTTP publish failure: undefined local variable or method `proxy_url' for #<Keen::HTTP::Sync:0x00000003469148>`