### PR TITLE
Enable post based query

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ This simplifes querying code where the analysis type is dynamic.
 Each query method or alias takes an optional hash of options as an additional parameter. Possible keys are:
 
 `:response` – Set to `:all_keys` to return the full API response (usually only the value of the `"result"` key is returned).
+`:method` - Set to `:post` to enable post body based query (https://keen.io/docs/data-analysis/post-queries/).
 
 ##### Getting Query URLs
 

--- a/lib/keen/client/querying_methods.rb
+++ b/lib/keen/client/querying_methods.rb
@@ -220,8 +220,14 @@ module Keen
       #   filters (optional) [Array]
       #   timezone (optional)
       def query(analysis_type, event_collection, params={}, options={})
-        url = _query_url(analysis_type, event_collection, params, options)
-        response = get_response(url)
+        response =
+          if options[:method] == :post
+            post_query(analysis_type, event_colection, params)
+          else
+            url = _query_url(analysis_type, event_collection, params, options)
+            get_response(url)
+          end
+
         response_body = response.body.chomp
         api_result = process_response(response.code, response_body)
         api_result = api_result["result"] unless options[:response] == :all_keys
@@ -229,6 +235,21 @@ module Keen
       end
 
       private
+
+      def post_query(analysis_type, event_collection, params={})
+        ensure_project_id!
+        ensure_read_key!
+
+        query_params = params.dup
+        query_params[:event_collection] = event_collection.to_s if event_collection
+        Keen::HTTP::Sync.new(self.api_url, self.proxy_url, self.read_timeout).post(
+          :path => api_query_resource_path(analysis_type),
+          :headers => api_headers(self.read_key, "sync"),
+          :body => MultiJson.encode(query_params)
+        )
+      rescue Exception => http_error
+        raise HttpError.new("Couldn't perform #{@analysis_type} on Keen IO: #{http_error.message}", http_error)
+      end
 
       def _query_url(analysis_type, event_collection, params={}, options={})
         ensure_project_id!

--- a/lib/keen/client/querying_methods.rb
+++ b/lib/keen/client/querying_methods.rb
@@ -222,7 +222,7 @@ module Keen
       def query(analysis_type, event_collection, params={}, options={})
         response =
           if options[:method] == :post
-            post_query(analysis_type, event_colection, params)
+            post_query(analysis_type, event_collection, params)
           else
             url = _query_url(analysis_type, event_collection, params, options)
             get_response(url)

--- a/spec/keen/client/querying_methods_spec.rb
+++ b/spec/keen/client/querying_methods_spec.rb
@@ -10,7 +10,7 @@ describe Keen::Client do
     :project_id => project_id, :read_key => read_key,
     :api_url => api_url ) }
 
-  def query_url(query_name, query_params)
+  def query_url(query_name, query_params = "")
     "#{api_url}/#{api_version}/projects/#{project_id}/queries/#{query_name}#{query_params}"
   end
 
@@ -146,6 +146,19 @@ describe Keen::Client do
         stub_keen_get(expected_url, 200, :result => [1])
         api_response = query.call("funnel", nil, { :steps => [] }, { :response => :all_keys })
         api_response.should == { "result" => [1] }
+      end
+
+      it "should call API with post body if method opton is set to post " do
+        steps = [{
+          :event_collection => "sign ups",
+          :actor_property => "user.id"
+        }]
+        expected_url = query_url("funnel")
+        stub_keen_post(expected_url, 200, :result => 1)
+        response = query.call("funnel", nil, { :steps => steps }, { :method => :post })
+
+        expect_keen_post(expected_url, { :steps => steps }, "sync", read_key)
+        response.should == api_response["result"]
       end
     end
   end


### PR DESCRIPTION
Hi, we'd like to allow option for post based query request as suggested in: https://keen.io/docs/data-analysis/post-queries/

For example:
```ruby
Keen.funnel steps: [],  response: :all_keys, method: :post
```