### PR TITLE
Manually encode ampersands (&) as required by the Keen redirect API.

### DIFF
--- a/lib/keen/client/publishing_methods.rb
+++ b/lib/keen/client/publishing_methods.rb
@@ -121,7 +121,7 @@ module Keen
       # @return a URL that will track an event when hit
       def redirect_url(event_collection, properties, redirect_url)
         require 'open-uri'
-        encoded_url = URI::encode(redirect_url)
+        encoded_url = CGI::escape(redirect_url)
         json = MultiJson.encode(properties)
         data = [json].pack("m0").tr("+/", "-_").gsub("\n", "")
         "#{self.api_url}#{api_event_collection_resource_path(event_collection)}?api_key=#{self.write_key}&data=#{data}&redirect=#{encoded_url}"

--- a/spec/keen/client/publishing_methods_spec.rb
+++ b/spec/keen/client/publishing_methods_spec.rb
@@ -328,7 +328,7 @@ describe Keen::Client::PublishingMethods do
   describe "redirect_url" do
     it "should return a url with a base-64 encoded json param and an encoded redirect url" do
       client.redirect_url("sign_ups", { :name => "Bob" }, "http://keen.io/?foo=bar&bar=baz").should ==
-        "#{api_url}/3.0/projects/12345/events/sign_ups?api_key=#{write_key}&data=eyJuYW1lIjoiQm9iIn0=&redirect=http://keen.io/?foo=bar&bar=baz"
+        "#{api_url}/3.0/projects/12345/events/sign_ups?api_key=#{write_key}&data=eyJuYW1lIjoiQm9iIn0=&redirect=http%3A%2F%2Fkeen.io%2F%3Ffoo%3Dbar%26bar%3Dbaz"
     end
   end
 


### PR DESCRIPTION
I came across an issue where only the first query param in the destination of a keen url was being preserved. Once you follow the keen redirect you'd end up at the destination page, with only the first param there.

```
ex: example.com?foo=bar&bat=baz => example.com?foo=bar # second param is lost
```

I reached out to support and they verified that the "&'s" in the redirect_url need to be escaped. This is a quick fix I used to get it done.