### PR TITLE
Saved queries support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 bundler_args: --without development
 
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.2.2
@@ -21,8 +20,6 @@ before_install:
 
 matrix:
   exclude:
-    - rvm: 1.8.7
-      env: PATTERN=synchrony
     - rvm: jruby-19mode
       env: PATTERN=synchrony
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@ source "https://rubygems.org"
 
 group :development, :test do
   gem 'rake'
-  gem 'rspec', '~>2'
   gem 'em-http-request'
   gem 'em-synchrony', :require => false
+  gem 'rspec', '~>2'
   gem 'webmock'
 end
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or install from Rubygems:
 
     gem install keen
 
-keen is tested with Ruby 1.8 and 1.9 on:
+keen is tested with Ruby 1.9.3 + and on:
 
 * MRI
 * Rubinius
@@ -177,9 +177,30 @@ Each query method or alias takes an optional hash of options as an additional pa
 `:response` – Set to `:all_keys` to return the full API response (usually only the value of the `"result"` key is returned).
 `:method` - Set to `:post` to enable post body based query (https://keen.io/docs/data-analysis/post-queries/).
 
-##### Query Caching
+### Saved Queries
 
-You can specify a `max_age` parameter as part of your query request, but make sure you send the request as a `:post` request.
+You can manage your saved queries from the Keen ruby client.
+
+```ruby
+# Create a saved query
+Keen.saved_queries.create("name", saved_query_attributes)
+
+# Get all saved queries
+Keen.saved_queries.all
+
+# Get one saved query
+Keen.saved_queries.get("saved-query-slug")
+
+# Get saved query with results
+Keen.saved_queries.get("saved-query-slug", results: true)
+
+# Update a saved query
+saved_query_attributes = { refresh_rate: 14400 }
+Keen.saved_queries.update("saved-query-slug", saved_query_attributes)
+
+# Delete a saved query
+Keen.saved_queries.delete("saved-query-slug")
+```
 
 ##### Getting Query URLs
 

--- a/lib/keen.rb
+++ b/lib/keen.rb
@@ -51,7 +51,8 @@ module Keen
                    :event_collections,
                    :project_info,
                    :query_url,
-                   :query
+                   :query,
+                   :saved_queries
 
     attr_writer :logger
 

--- a/lib/keen/client.rb
+++ b/lib/keen/client.rb
@@ -3,6 +3,7 @@ require 'keen/version'
 require 'keen/client/publishing_methods'
 require 'keen/client/querying_methods'
 require 'keen/client/maintenance_methods'
+require 'keen/client/saved_queries'
 require 'openssl'
 require 'multi_json'
 require 'base64'
@@ -51,6 +52,10 @@ module Keen
       self.proxy_url, self.proxy_type = options.values_at(:proxy_url, :proxy_type)
 
       self.read_timeout = options[:read_timeout].to_f unless options[:read_timeout].nil?
+    end
+
+    def saved_queries
+      @saved_queries ||= SavedQueries.new(self)
     end
 
     private

--- a/lib/keen/client/saved_queries.rb
+++ b/lib/keen/client/saved_queries.rb
@@ -1,0 +1,82 @@
+require "json"
+
+class SavedQueries
+  def initialize(client)
+    @client = client
+  end
+
+  def all
+    process_response(saved_query_response)
+  end
+
+  def get(saved_query_name, results: false)
+    saved_query_path = "/#{saved_query_name}"
+    if results
+      saved_query_path += "/result"
+    end
+    response = saved_query_response(saved_query_path)
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    process_response(response)
+  end
+
+  def create(saved_query_name, saved_query_body)
+    response = Keen::HTTP::Sync.new(client.api_url, client.proxy_url, client.read_timeout).put(
+      path: "#{saved_query_base_url}/#{saved_query_name}",
+      headers: api_headers(client.master_key, "sync"),
+      body: saved_query_body
+    )
+    process_response(response)
+  end
+  alias_method :update, :create
+
+  def delete(saved_query_name)
+    response = Keen::HTTP::Sync.new(client.api_url, client.proxy_url, client.read_timeout).delete(
+      path: "#{saved_query_base_url}/#{saved_query_name}",
+      headers: api_headers(client.master_key, "sync")
+    )
+    process_response(response)
+  end
+
+  private
+
+  attr_reader :client
+
+  def saved_query_response(path = "")
+    Keen::HTTP::Sync.new(client.api_url, client.proxy_url, client.read_timeout).get(
+      path: saved_query_base_url + path,
+      headers: api_headers(client.master_key, "sync")
+    )
+  end
+
+  def saved_query_base_url
+    "/#{client.api_version}/projects/#{client.project_id}/queries/saved"
+  end
+
+  def api_headers(authorization, sync_type)
+    user_agent = "keen-gem, v#{Keen::VERSION}, #{sync_type}"
+    user_agent += ", #{RUBY_VERSION}, #{RUBY_PLATFORM}, #{RUBY_PATCHLEVEL}"
+    if defined?(RUBY_ENGINE)
+      user_agent += ", #{RUBY_ENGINE}"
+    end
+    { "Content-Type" => "application/json",
+      "User-Agent" => user_agent,
+      "Authorization" => authorization }
+  end
+
+  def process_response(response)
+    case response.code.to_i
+    when 204
+      true
+    when 200..299
+      JSON.parse(response.body, symbolize_names: true)
+    when 400
+      raise Keen::BadRequestError.new(response.body)
+    when 401
+      raise Keen::AuthenticationError.new(response.body)
+    when 404
+      raise Keen::NotFoundError.new(response.body)
+    else
+      raise Keen::HttpError.new(response.body)
+    end
+  end
+end

--- a/lib/keen/http.rb
+++ b/lib/keen/http.rb
@@ -32,6 +32,12 @@ module Keen
         @http.post(path, body, headers)
       end
 
+      def put(options)
+        path, headers, body = options.values_at(
+          :path, :headers, :body)
+        @http.put(path, body, headers)
+      end
+
       def get(options)
         path, headers = options.values_at(
           :path, :headers)

--- a/spec/integration/saved_query_spec.rb
+++ b/spec/integration/saved_query_spec.rb
@@ -1,0 +1,34 @@
+require File.expand_path("../spec_helper", __FILE__)
+
+describe "Saved Queries" do
+  let(:project_id) { ENV["KEEN_PROJECT_ID"] }
+  let(:master_key) { ENV["KEEN_MASTER_KEY"] }
+  let(:client) { Keen::Client.new(project_id: project_id, master_key: master_key) }
+
+  describe "#all" do
+    it "gets all saved_queries" do
+      expect(client.saved_queries.all).to be_instance_of(Array)
+    end
+  end
+
+  describe "#get" do
+    it "gets a single saved query" do
+      all_queries = client.saved_queries.all
+
+      single_saved_query = client.saved_queries.get(all_queries.first[:query_name])
+
+      expect(single_saved_query[:query_name]).to eq(all_queries.first[:query_name])
+      expect(single_saved_query[:results]).to be_nil
+    end
+  end
+
+  describe "#results" do
+    it "gets a single saved query" do
+      all_queries = client.saved_queries.all
+
+      single_saved_query = client.saved_queries.get(all_queries.last[:query_name], results: true)
+
+      expect(single_saved_query[:result]).not_to be_nil
+    end
+  end
+end

--- a/spec/keen/saved_query_spec.rb
+++ b/spec/keen/saved_query_spec.rb
@@ -1,0 +1,165 @@
+require File.expand_path("../spec_helper", __FILE__)
+
+describe Keen do
+  let(:client) do
+    Keen::Client.new(
+      project_id: "12341234",
+      master_key: "abcdef",
+      api_url: "https://notreal.keen.io"
+    )
+  end
+
+  describe "#saved_queries" do
+    describe "#all" do
+
+      it "returns all saved queries" do
+        all_saved_queries = [ {
+          refresh_rate: 0,
+          last_modified_date: "2015-10-19T20:14:29.797000+00:00",
+          query_name: "Analysis-API-Calls-this-1-day",
+          query: {
+            filters: [],
+            analysis_type: "count",
+            timezone: "UTC",
+            timeframe: "this_1_days",
+            event_collection: "analysis_api_call"
+          },
+          metadata: {
+            visualization: { chart_type: "metric"}
+          }
+        } ]
+        stub_keen_get(saved_query_endpoint, 200, all_saved_queries)
+
+        all_saved_queries_response = client.saved_queries.all
+
+        expect(all_saved_queries_response).to eq(all_saved_queries)
+      end
+    end
+
+    describe "#get" do
+      it "returns a specific saved query given a query id" do
+        saved_query = {
+          refresh_rate: 0,
+          last_modified_date: "2015-10-19T20:14:29.797000+00:00",
+          query_name: "Analysis-API-Calls-this-1-day",
+          query: {
+            filters: [],
+            analysis_type: "count",
+            timezone: "UTC",
+            timeframe: "this_1_days",
+            event_collection: "analysis_api_call"
+          },
+          metadata: {
+            visualization: { chart_type: "metric"}
+          }
+        }
+        stub_keen_get(
+          saved_query_endpoint + "/#{saved_query[:query_name]}",
+          200,
+          saved_query
+        )
+
+        saved_query_response = client.saved_queries.get("Analysis-API-Calls-this-1-day")
+
+        expect(saved_query_response).to eq(saved_query)
+      end
+
+      it "throws an exception if service can't find saved query" do
+        saved_query = {
+          message: "Resource not found",
+          error_code: "ResourceNotFoundError"
+        }
+        stub_keen_get(
+          saved_query_endpoint + "/missing-query",
+          404,
+          saved_query
+        )
+
+        expect {
+          client.saved_queries.get("missing-query")
+        }.to raise_error(Keen::NotFoundError)
+      end
+    end
+
+    describe "#create" do
+      it "returns the created saved query when creation is successful" do
+        saved_query = {
+          refresh_rate: 0,
+          last_modified_date: "2015-10-19T20:14:29.797000+00:00",
+          query_name: "new-query",
+          query: {
+            filters: [],
+            analysis_type: "count",
+            timezone: "UTC",
+            timeframe: "this_1_days",
+            event_collection: "analysis_api_call"
+          },
+          metadata: {
+            visualization: { chart_type: "metric"}
+          }
+        }
+        stub_keen_put(
+          saved_query_endpoint + "/#{saved_query[:query_name]}", 201, saved_query
+        )
+
+        saved_query_response = client.saved_queries.create(saved_query[:query_name], saved_query)
+
+        expect(saved_query_response).to eq(saved_query)
+      end
+
+      it "raises an error when creation is unsuccessful" do
+        stub_keen_put(
+          saved_query_endpoint + "/saved-query-name", 400, {}
+        )
+
+        expect {
+          client.saved_queries.create("saved-query-name", {})
+        }.to raise_error(Keen::BadRequestError)
+      end
+    end
+
+    describe "#update" do
+      it "returns the created saved query when update is successful" do
+        saved_query = {
+          refresh_rate: 0,
+          last_modified_date: "2015-10-19T20:14:29.797000+00:00",
+          query_name: "new-query",
+          query: {
+            filters: [],
+            analysis_type: "count",
+            timezone: "UTC",
+            timeframe: "this_1_days",
+            event_collection: "analysis_api_call"
+          },
+          metadata: {
+            visualization: { chart_type: "metric"}
+          }
+        }
+        stub_keen_put(
+          saved_query_endpoint + "/#{saved_query[:query_name]}", 200, saved_query
+        )
+
+        saved_query_response = client.saved_queries.update(saved_query[:query_name], saved_query)
+
+        expect(saved_query_response).to eq(saved_query)
+      end
+    end
+
+    describe "#delete" do
+      it "returns true with deletion is successful" do
+        query_name = "query-to-be-deleted"
+        stub_keen_delete(
+          saved_query_endpoint + "/#{query_name}", 204
+        )
+
+        saved_query_response = client.saved_queries.delete(query_name)
+
+        expect(saved_query_response).to eq(true)
+      end
+    end
+  end
+
+  def saved_query_endpoint
+    client.api_url + "/#{client.api_version}/projects/#{client.project_id}/queries/saved"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,10 @@ module Keen::SpecHelpers
     stub_keen_request(:post, url, status, MultiJson.encode(response_body))
   end
 
+  def stub_keen_put(url, status, response_body)
+    stub_keen_request(:put, url, status, MultiJson.encode(response_body))
+  end
+
   def stub_keen_get(url, status, response_body)
     stub_keen_request(:get, url, status, MultiJson.encode(response_body))
   end


### PR DESCRIPTION
This commit adds support for saved queries in the Ruby gem.

Please read the `README` to see how it works. Here are the basic changes to the ruby gem:

```ruby
# Create a saved query
Keen.saved_queries.create("name", saved_query_attributes)

# Get all saved queries
Keen.saved_queries.all

# Get one saved query
Keen.saved_queries.get("saved-query-slug")

# Get saved query with results
Keen.saved_queries.get("saved-query-slug", results: true)

# Update a saved query
saved_query_attributes = { refresh_rate: 14400 }
Keen.saved_queries.update("saved-query-slug", saved_query_attributes)

# Delete a saved query
Keen.saved_queries.delete("saved-query-slug")
```