### PR TITLE
Relax constraint on addressable

### DIFF
--- a/keen.gemspec
+++ b/keen.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.add_dependency "multi_json", "~> 1.3"
-  s.add_dependency "addressable", "~> 2.3.5"
+  s.add_dependency "addressable", "~> 2.3"
   s.add_dependency "jruby-openssl" if defined?(JRUBY_VERSION)
 
   s.add_dependency 'rubysl', '~> 2.0' if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'


### PR DESCRIPTION
The addressable gem is up to v2.4.0. Unless there's a bug-level feature that you need in v2.3.5, relaxing the constraint to just ~> 2.3 will make the gem easier to use by consumers.
