### PR TITLE
Add a rake task to start a console

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,5 +21,10 @@ RSpec::Core::RakeTask.new(:pattern) do |t|
   t.pattern = "spec/#{ENV['PATTERN']}/**/*_spec.rb"
 end
 
+desc "Start a development console with local code loaded"
+task :console do
+  exec "irb -r keen -I ./lib"
+end
+
 task :default => :spec
 task :test => [:spec]


### PR DESCRIPTION
When evaluating changes made in development, it's convenient to be able to spawn a console with the current state of the code loaded. This adds a task `rake console` to start irb with the local code pre-required.
