### PR TITLE
Add basic query logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ Each query method or alias takes an optional hash of options as an additional pa
 `:response` – Set to `:all_keys` to return the full API response (usually only the value of the `"result"` key is returned).
 `:method` - Set to `:post` to enable post body based query (https://keen.io/docs/data-analysis/post-queries/).
 
+##### Query Logging
+
+You can log all GET and POST queries automatically by setting the `log_queries` option.
+
+``` ruby
+Keen.log_queries = true
+Keen.count('purchases')
+# I, [2016-10-30T11:45:24.678745 #9978]  INFO -- : [KEEN] Send GET query to https://api.keen.io/3.0/projects/<YOUR_PROJECT_ID>/queries/count?event_collection=purchases with options {}
+```
+
 ### Saved Queries
 
 You can manage your saved queries from the Keen ruby client.

--- a/lib/keen.rb
+++ b/lib/keen.rb
@@ -31,7 +31,8 @@ module Keen
                    :write_key, :write_key=,
                    :read_key, :read_key=,
                    :master_key, :master_key=,
-                   :api_url, :api_url=
+                   :api_url, :api_url=,
+                   :log_queries, :log_queries=
 
     def_delegators :default_client,
                    :proxy_url, :proxy_url=,

--- a/lib/keen/client.rb
+++ b/lib/keen/client.rb
@@ -16,7 +16,7 @@ module Keen
     include Keen::Client::QueryingMethods
     include Keen::Client::MaintenanceMethods
 
-    attr_accessor :project_id, :write_key, :read_key, :master_key, :api_url, :proxy_url, :proxy_type, :read_timeout
+    attr_accessor :project_id, :write_key, :read_key, :master_key, :api_url, :proxy_url, :proxy_type, :read_timeout, :log_queries
 
     CONFIG = {
       :api_url => "https://api.keen.io",

--- a/lib/keen/client/querying_methods.rb
+++ b/lib/keen/client/querying_methods.rb
@@ -240,6 +240,8 @@ module Keen
         ensure_project_id!
         ensure_read_key!
 
+        log_query("#{self.api_url}#{api_query_resource_path(analysis_type)}", 'POST', params) if log_queries
+
         query_params = params.dup
         query_params[:event_collection] = event_collection.to_s if event_collection
         Keen::HTTP::Sync.new(self.api_url, self.proxy_url, self.read_timeout).post(
@@ -261,6 +263,7 @@ module Keen
       end
 
       def get_response(url)
+        log_query(url) if log_queries
         uri = URI.parse(url)
         Keen::HTTP::Sync.new(self.api_url, self.proxy_url, self.read_timeout).get(
           :path => "#{uri.path}?#{uri.query}",
@@ -272,6 +275,10 @@ module Keen
 
       def api_query_resource_path(analysis_type)
         "/#{self.api_version}/projects/#{self.project_id}/queries/#{analysis_type}"
+      end
+
+      def log_query(url, method='GET', options={})
+        Keen.logger.info { "[KEEN] Send #{method} query to #{url} with options #{options}" }
       end
     end
   end

--- a/spec/keen/client/querying_methods_spec.rb
+++ b/spec/keen/client/querying_methods_spec.rb
@@ -148,17 +148,45 @@ describe Keen::Client do
         api_response.should == { "result" => [1] }
       end
 
-      it "should call API with post body if method opton is set to post " do
-        steps = [{
-          :event_collection => "sign ups",
-          :actor_property => "user.id"
-        }]
-        expected_url = query_url("funnel")
-        stub_keen_post(expected_url, 200, :result => 1)
-        response = query.call("funnel", nil, { :steps => steps }, { :method => :post })
+      context "if log_queries is true" do
+        before(:each) { client.log_queries = true }
 
-        expect_keen_post(expected_url, { :steps => steps }, "sync", read_key)
-        response.should == api_response["result"]
+        it "logs the query" do
+          expect(client).to receive(:log_query).with(query_url("count", "?event_collection=users"))
+          test_query
+        end
+
+        after(:each) { client.log_queries = false }
+      end
+
+      context "if method option is set to post" do
+        let(:steps) do
+          [{
+            :event_collection => "sign ups",
+            :actor_property => "user.id"
+          }]
+        end
+        let(:expected_url) { query_url("funnel") }
+        before(:each) { stub_keen_post(expected_url, 200, :result => 1) }
+
+        it "should call API with post body" do
+          response = query.call("funnel", nil, { :steps => steps }, { :method => :post })
+
+          expect_keen_post(expected_url, { :steps => steps }, "sync", read_key)
+          response.should == api_response["result"]
+        end
+
+        context "if log_queries is true" do
+          before(:each) { client.log_queries = true }
+
+          it "logs the query" do
+            expected_params = {:steps=>[{:event_collection=>"sign ups", :actor_property=>"user.id"}]}
+            expect(client).to receive(:log_query).with(expected_url, 'POST', expected_params)
+            query.call("funnel", nil, { :steps => steps }, { :method => :post })
+          end
+
+          after(:each) { client.log_queries = false }
+        end
       end
     end
   end


### PR DESCRIPTION
Added an option to log queries that will send an info message to the current logger every time a GET or POST query is executed, listing the url, method and options. There's definitely some room for improvement here, but it seemed as good a place to start as any.

This is meant to start addressing https://github.com/keenlabs/keen-gem/issues/84
