### PR TITLE
Add a rake task to start a console

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,16 @@ Similarly, you can use guard to listen for changes to files and run specs.
 
 `bundle exec guard -g synchrony`
 
+#### Running a Local Console
+
+You can spawn an `irb` session with the local files already loaded for debugging
+or experimentation.
+
+```
+$ bundle exec rake console
+2.2.6 :001 > Keen
+ => Keen 
+```
 ### Community Contributors
 + [alexkwolfe](https://github.com/alexkwolfe)
 + [peteygao](https://github.com/peteygao)

--- a/Rakefile
+++ b/Rakefile
@@ -21,5 +21,10 @@ RSpec::Core::RakeTask.new(:pattern) do |t|
   t.pattern = "spec/#{ENV['PATTERN']}/**/*_spec.rb"
 end
 
+desc "Start a development console with local code loaded"
+task :console do
+  exec "irb -r keen -I ./lib"
+end
+
 task :default => :spec
 task :test => [:spec]


### PR DESCRIPTION
When evaluating changes made in development, it's convenient to be able to spawn a console with the current state of the code loaded. This adds a task rake console to start irb with the local code pre-required.

This is a reissue after merging in `upstream/master`