### PR TITLE
add a header for SDK tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,9 @@ If you want some bot protection, check out the [Voight-Kampff](https://github.co
 
 ### Changelog
 
+##### 0.9.7
++ Added a new header `Keen-Sdk` that sends the SDK version information on all requests.
+
 ##### 0.9.6
 + Updated behavior of saved queries to allow fetching results using the READ KEY as opposed to requiring the MASTER KEY, making the gem consistent with https://keen.io/docs/api/#getting-saved-query-results 
 

--- a/lib/keen/client.rb
+++ b/lib/keen/client.rb
@@ -4,6 +4,7 @@ require 'keen/client/publishing_methods'
 require 'keen/client/querying_methods'
 require 'keen/client/maintenance_methods'
 require 'keen/client/saved_queries'
+require 'keen/version'
 require 'openssl'
 require 'multi_json'
 require 'base64'
@@ -29,7 +30,8 @@ module Keen
         end
         { "Content-Type" => "application/json",
           "User-Agent" => user_agent,
-          "Authorization" => authorization }
+          "Authorization" => authorization,
+          "X-Keensdkversion-X" => "ruby-#{Keen::VERSION}" }
       }
     }
 

--- a/lib/keen/client.rb
+++ b/lib/keen/client.rb
@@ -31,7 +31,7 @@ module Keen
         { "Content-Type" => "application/json",
           "User-Agent" => user_agent,
           "Authorization" => authorization,
-          "X-Keensdkversion-X" => "ruby-#{Keen::VERSION}" }
+          "Keen-Sdk" => "ruby-#{Keen::VERSION}" }
       }
     }
 

--- a/lib/keen/client/saved_queries.rb
+++ b/lib/keen/client/saved_queries.rb
@@ -66,7 +66,7 @@ class SavedQueries
     { "Content-Type" => "application/json",
       "User-Agent" => user_agent,
       "Authorization" => authorization,
-      "X-Keensdkversion-X" => "ruby-#{Keen::VERSION}" }
+      "Keen-Sdk" => "ruby-#{Keen::VERSION}" }
   end
 
   def process_response(response)

--- a/lib/keen/client/saved_queries.rb
+++ b/lib/keen/client/saved_queries.rb
@@ -1,3 +1,4 @@
+require 'keen/version'
 require "json"
 
 class SavedQueries
@@ -17,6 +18,7 @@ class SavedQueries
       # The results path should use the READ KEY
       api_key = client.read_key
     end
+
     response = saved_query_response(api_key, saved_query_path)
     response_body = JSON.parse(response.body, symbolize_names: true)
     process_response(response)
@@ -63,7 +65,8 @@ class SavedQueries
     end
     { "Content-Type" => "application/json",
       "User-Agent" => user_agent,
-      "Authorization" => authorization }
+      "Authorization" => authorization,
+      "X-Keensdkversion-X" => "ruby-#{Keen::VERSION}" }
   end
 
   def process_response(response)

--- a/lib/keen/version.rb
+++ b/lib/keen/version.rb
@@ -1,3 +1,3 @@
 module Keen
-  VERSION = "0.9.6"
+  VERSION = "0.9.7"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,7 +40,8 @@ module Keen::SpecHelpers
 
     headers = { "Content-Type" => "application/json",
                 "User-Agent" => user_agent,
-                "Authorization" => read_or_write_key }
+                "Authorization" => read_or_write_key,
+                "X-Keensdkversion-X" => "ruby-#{Keen::VERSION}" }
 
     WebMock.should have_requested(method, url).with(
       :body => body,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,7 +41,7 @@ module Keen::SpecHelpers
     headers = { "Content-Type" => "application/json",
                 "User-Agent" => user_agent,
                 "Authorization" => read_or_write_key,
-                "X-Keensdkversion-X" => "ruby-#{Keen::VERSION}" }
+                "Keen-Sdk" => "ruby-#{Keen::VERSION}" }
 
     WebMock.should have_requested(method, url).with(
       :body => body,


### PR DESCRIPTION
Adds a new header to all requests showing the SDK version. The header is `X-Keensdkversion-X`, and will pull the version number from `/lib/keen/version.rb`... so the header will have a value of something like `ruby-1.2.3`