### PR TITLE
Allow sending arbitrary headers for requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,9 @@ If you want some bot protection, check out the [Voight-Kampff](https://github.co
 
 ### Changelog
 
+##### 0.9.9
++ Added the ability to send additional optional headers.
+
 ##### 0.9.7
 + Added a new header `Keen-Sdk` that sends the SDK version information on all requests.
 

--- a/lib/keen/client/publishing_methods.rb
+++ b/lib/keen/client/publishing_methods.rb
@@ -10,7 +10,7 @@ module Keen
       #
       # @return the JSON response from the API
       def add_event(event_collection, properties, options={})
-        self.publish(event_collection, properties, options)
+        self.publish(event_collection, properties)
       end
 
       # Publishes a synchronous event

--- a/lib/keen/version.rb
+++ b/lib/keen/version.rb
@@ -1,3 +1,3 @@
 module Keen
-  VERSION = "0.9.8"
+  VERSION = "0.9.9"
 end

--- a/spec/keen/client/maintenance_methods_spec.rb
+++ b/spec/keen/client/maintenance_methods_spec.rb
@@ -20,7 +20,7 @@ describe Keen::Client do
     it 'should not require filters' do
       url = delete_url(event_collection)
       stub_keen_delete(url, 204)
-      client.delete(event_collection).should == true
+      expect(client.delete(event_collection)).to be true
       expect_keen_delete(url, "sync", master_key)
     end
 
@@ -42,7 +42,7 @@ describe Keen::Client do
 
     it "should fetch the project's event resource" do
       stub_keen_get(events_url, 200, [{ "a" => 1 }, { "b" => 2 }] )
-      client.event_collections.should == [{ "a" => 1 }, { "b" => 2 }]
+      expect(client.event_collections).to match_array([{ "a" => 1 }, { "b" => 2 }])
       expect_keen_get(events_url, "sync", master_key)
     end
   end
@@ -53,7 +53,7 @@ describe Keen::Client do
 
     it "should fetch the project's named event resource" do
       stub_keen_get(events_url, 200, [{ "b" => 2 }] )
-      client.event_collection(event_collection).should == [{ "b" => 2 }]
+      expect(client.event_collection(event_collection)).to match_array([{ "b" => 2 }])
       expect_keen_get(events_url, "sync", master_key)
     end
   end
@@ -63,7 +63,7 @@ describe Keen::Client do
 
     it "should fetch the project resource" do
       stub_keen_get(project_url, 200, [{ "a" => 1 }, { "b" => 2 }] )
-      client.project_info.should == [{ "a" => 1 }, { "b" => 2 }]
+      expect(client.project_info).to match_array([{ "a" => 1 }, { "b" => 2 }])
       expect_keen_get(project_url, "sync", master_key)
     end
   end

--- a/spec/keen/client/publishing_methods_spec.rb
+++ b/spec/keen/client/publishing_methods_spec.rb
@@ -21,7 +21,7 @@ describe Keen::Client::PublishingMethods do
     it "should return the proper response" do
       api_response = { "created" => true }
       stub_keen_post(api_event_collection_resource_url(api_url, collection), 201, api_response)
-      client.publish(collection, event_properties).should == api_response
+      expect(client.publish(collection, event_properties)).to eq(api_response)
     end
 
     it "should raise an argument error if no event collection is specified" do
@@ -51,9 +51,9 @@ describe Keen::Client::PublishingMethods do
         e = exception
       end
 
-      e.class.should == Keen::HttpError
-      e.original_error.should be_kind_of(Timeout::Error)
-      e.message.should == "Keen IO Exception: HTTP publish failure: execution expired"
+      expect(e.class).to eq(Keen::HttpError)
+      expect(e.original_error).to be_kind_of(Timeout::Error)
+      expect(e.message).to eq("Keen IO Exception: HTTP publish failure: execution expired")
     end
 
     it "should raise an exception if client has no project_id" do
@@ -84,7 +84,7 @@ describe Keen::Client::PublishingMethods do
       it "should return the proper response" do
         api_response = { "created" => true }
         stub_keen_post(api_event_collection_resource_url(api_url, collection), 201, api_response)
-        client.publish(collection, event_properties).should == api_response
+        expect(client.publish(collection, event_properties)).to eq(api_response)
       end
     end
   end
@@ -187,7 +187,7 @@ describe Keen::Client::PublishingMethods do
           EM.run {
             client.publish_async(collection, event_properties).callback { |response|
               begin
-                response.should == api_success
+                expect(response).to eq(api_success)
               ensure
                 EM.stop
               end
@@ -200,8 +200,8 @@ describe Keen::Client::PublishingMethods do
           EM.run {
             client.publish_async(collection, event_properties).errback { |error|
               begin
-                error.should_not be_nil
-                error.message.should == "Keen IO Exception: HTTP publish_async failure: WebMock timeout error"
+                expect(error).to_not be_nil
+                expect(error.message).to eq("Keen IO Exception: HTTP publish_async failure: WebMock timeout error")
               ensure
                 EM.stop
               end
@@ -221,7 +221,7 @@ describe Keen::Client::PublishingMethods do
                 end
               }
             }
-          }.to raise_error
+          }.to raise_error(NameError)
         end
       end
     end
@@ -265,7 +265,7 @@ describe Keen::Client::PublishingMethods do
           EM.run {
             client.publish_batch_async(events).callback { |response|
               begin
-                response.should == api_success
+                expect(response).to eq(api_success)
               ensure
                 EM.stop
               end
@@ -278,8 +278,8 @@ describe Keen::Client::PublishingMethods do
           EM.run {
             client.publish_batch_async(events).errback { |error|
               begin
-                error.should_not be_nil
-                error.message.should == "Keen IO Exception: HTTP publish_async failure: WebMock timeout error"
+                expect(error).to_not be_nil
+                expect(error.message).to eq("Keen IO Exception: HTTP publish_async failure: WebMock timeout error")
               ensure
                 EM.stop
               end
@@ -299,7 +299,7 @@ describe Keen::Client::PublishingMethods do
                 end
               }
             }
-          }.to raise_error
+          }.to raise_error(NameError)
         end
       end
     end
@@ -313,22 +313,20 @@ describe Keen::Client::PublishingMethods do
 
   describe "#add_event" do
     it "should alias to publish" do
-      client.should_receive(:publish).with("users", {:a => 1}, {:b => 2})
-      client.add_event("users", {:a => 1}, {:b => 2})
+      expect(client).to receive(:publish).with(collection, {:a => 1})
+      client.add_event(collection, {:a => 1}, {:b => 2})
     end
   end
 
   describe "beacon_url" do
     it "should return a url with a base-64 encoded json param" do
-      client.beacon_url("sign_ups", { :name => "Bob" }).should ==
-        "#{api_url}/3.0/projects/12345/events/sign_ups?api_key=#{write_key}&data=eyJuYW1lIjoiQm9iIn0="
+      expect(client.beacon_url("sign_ups", { :name => "Bob" })).to eq("#{api_url}/3.0/projects/12345/events/sign_ups?api_key=#{write_key}&data=eyJuYW1lIjoiQm9iIn0=")
     end
   end
 
   describe "redirect_url" do
     it "should return a url with a base-64 encoded json param and an encoded redirect url" do
-      client.redirect_url("sign_ups", { :name => "Bob" }, "http://keen.io/?foo=bar&bar=baz").should ==
-        "#{api_url}/3.0/projects/12345/events/sign_ups?api_key=#{write_key}&data=eyJuYW1lIjoiQm9iIn0=&redirect=http%3A%2F%2Fkeen.io%2F%3Ffoo%3Dbar%26bar%3Dbaz"
+      expect(client.redirect_url("sign_ups", { :name => "Bob" }, "http://keen.io/?foo=bar&bar=baz")).to eq("#{api_url}/3.0/projects/12345/events/sign_ups?api_key=#{write_key}&data=eyJuYW1lIjoiQm9iIn0=&redirect=http%3A%2F%2Fkeen.io%2F%3Ffoo%3Dbar%26bar%3Dbaz")
     end
   end
 

--- a/spec/keen/client/querying_methods_spec.rb
+++ b/spec/keen/client/querying_methods_spec.rb
@@ -19,14 +19,14 @@ describe Keen::Client do
 
     ["minimum", "maximum", "sum", "average", "count", "count_unique", "select_unique", "extraction", "multi_analysis", "median", "percentile"].each do |query_name|
       it "should call keen query passing the query name" do
-        client.should_receive(:query).with(query_name.to_sym, event_collection, params, {})
+        expect(client).to receive(:query).with(query_name.to_sym, event_collection, params, {})
         client.send(query_name, event_collection, params)
       end
     end
 
     describe "funnel" do
       it "should call keen query w/o event collection" do
-        client.should_receive(:query).with(:funnel, nil, params, {})
+        expect(client).to receive(:query).with(:funnel, nil, params, {})
         client.funnel(params)
       end
     end
@@ -58,7 +58,7 @@ describe Keen::Client do
         expected_url = query_url(query_name, expected_query_params)
         stub_keen_get(expected_url, 200, :result => 1)
         response = query.call(query_name, event_collection, extra_query_hash)
-        response.should == api_response["result"]
+        expect(response).to eq(api_response["result"])
         expect_keen_get(expected_url, "sync", read_key)
       end
 
@@ -138,14 +138,14 @@ describe Keen::Client do
         timeframe_str =  CGI.escape(MultiJson.encode(timeframe))
 
         test_query("&timeframe=#{timeframe_str}", options = {:timeframe => timeframe})
-        options.should eq({:timeframe => timeframe})
+        expect(options).to eq({:timeframe => timeframe})
       end
 
       it "should return the full API response if the response option is set to all_keys" do
         expected_url = query_url("funnel", "?steps=#{MultiJson.encode([])}")
         stub_keen_get(expected_url, 200, :result => [1])
         api_response = query.call("funnel", nil, { :steps => [] }, { :response => :all_keys })
-        api_response.should == { "result" => [1] }
+        expect(api_response).to eq({ "result" => [1] })
       end
 
       it "should call API with post body if method opton is set to post " do
@@ -158,7 +158,22 @@ describe Keen::Client do
         response = query.call("funnel", nil, { :steps => steps }, { :method => :post })
 
         expect_keen_post(expected_url, { :steps => steps }, "sync", read_key)
-        response.should == api_response["result"]
+        expect(response).to eq(api_response["result"])
+      end
+
+      it "should add extra headers if you supply them as an option" do
+        url = query_url("count", "?event_collection=#{event_collection}")
+        extra_headers = {
+          "Keen-Flibbity-Flabbidy" => "foobar"
+        }
+
+        options = {
+          :headers => extra_headers
+        }
+
+        stub_keen_get(url, 200, :result => 10)
+        client.count(event_collection, {}, options)
+        expect_keen_get(url, "sync", read_key, extra_headers)
       end
     end
   end
@@ -171,14 +186,14 @@ describe Keen::Client do
     end
 
     it "should not require params" do
-      client.count(event_collection).should == 10
+      expect(client.count(event_collection)).to eq(10)
       expect_keen_get(url, "sync", read_key)
     end
 
     context "with event collection as symbol" do
       let(:event_collection) { :users }
       it "should not require a string" do
-        client.count(event_collection).should == 10
+        expect(client.count(event_collection)).to eq(10)
       end
     end
   end
@@ -188,7 +203,7 @@ describe Keen::Client do
       query_params = "?event_collection=#{event_collection}"
       url = query_url("extraction", query_params)
       stub_keen_get(url, 200, :result => { "a" => 1 } )
-      client.extraction(event_collection).should == { "a" => 1 }
+      expect(client.extraction(event_collection)).to eq({ "a" => 1 })
       expect_keen_get(url, "sync", read_key)
     end
   end
@@ -207,7 +222,7 @@ describe Keen::Client do
     end
 
     it "should not run the query" do
-      Keen::HTTP::Sync.should_not receive(:new)
+      expect(Keen::HTTP::Sync).to_not receive(:new)
     end
   end
 end

--- a/spec/keen/client_spec.rb
+++ b/spec/keen/client_spec.rb
@@ -20,9 +20,9 @@ describe Keen::Client do
     context "deprecated" do
       it "should allow created via project_id and key args" do
         client = Keen::Client.new(project_id, write_key, read_key)
-        client.write_key.should == write_key
-        client.read_key.should == read_key
-        client.project_id.should == project_id
+        expect(client.write_key).to eq(write_key)
+        expect(client.read_key).to eq(read_key)
+        expect(client.project_id).to eq(project_id)
       end
     end
 
@@ -33,15 +33,15 @@ describe Keen::Client do
         :read_key => read_key,
         :api_url => api_url,
         :read_timeout => read_timeout)
-      client.write_key.should == write_key
-      client.read_key.should == read_key
-      client.project_id.should == project_id
-      client.api_url.should == api_url
-      client.read_timeout.should == read_timeout
+      expect(client.write_key).to eq(write_key)
+      expect(client.read_key).to eq(read_key)
+      expect(client.project_id).to eq(project_id)
+      expect(client.api_url).to eq(api_url)
+      expect(client.read_timeout).to eq(read_timeout)
     end
 
     it "should set a default api_url" do
-      Keen::Client.new.api_url.should == "https://api.keen.io"
+      expect(Keen::Client.new.api_url).to eq("https://api.keen.io")
     end
   end
 
@@ -51,11 +51,11 @@ describe Keen::Client do
     let (:process_response) { client.method(:process_response) }
 
     it "should return encoded json for a 200" do
-      process_response.call(200, body).should == { "wazzup" => 1 }
+      expect(process_response.call(200, body)).to eq({ "wazzup" => 1 })
     end
 
     it "should return encoded json for a 201" do
-      process_response.call(201, body).should == { "wazzup" => 1 }
+      expect(process_response.call(201, body)).to eq({ "wazzup" => 1 })
     end
 
     it "should return empty for bad json on a 200/201" do

--- a/spec/keen/keen_spec.rb
+++ b/spec/keen/keen_spec.rb
@@ -17,31 +17,31 @@ describe Keen do
       let(:client) { Keen.send(:default_client) }
 
       it "should set a project id from the environment" do
-        client.project_id.should == "12345"
+        expect(client.project_id).to eq("12345")
       end
 
       it "should set a write key from the environment" do
-        client.write_key.should == "abcdewrite"
+        expect(client.write_key).to eq("abcdewrite")
       end
 
       it "should set a read key from the environment" do
-        client.read_key.should == "abcderead"
+        expect(client.read_key).to eq("abcderead")
       end
 
       it "should set a master key from the environment" do
-        client.master_key.should == "lalalala"
+        expect(client.master_key).to eq("lalalala")
       end
 
       it "should set an api host from the environment" do
-        client.api_url.should == "http://fake.keen.io:fakeport"
+        expect(client.api_url).to eq("http://fake.keen.io:fakeport")
       end
 
       it "should set an proxy host from the environment" do
-        client.proxy_url.should == "http://proxy.keen.io:proxyport"
+        expect(client.proxy_url).to eq("http://proxy.keen.io:proxyport")
       end
 
       it "should set an proxy type from the environment" do
-        client.proxy_type.should == "http"
+        expect(client.proxy_type).to eq("http")
       end
     end
   end
@@ -49,7 +49,7 @@ describe Keen do
   describe "Keen delegation" do
     it "should memoize the default client, retaining settings" do
       Keen.project_id = "new-abcde"
-      Keen.project_id.should == "new-abcde"
+      expect(Keen.project_id).to eq("new-abcde")
     end
 
     after do
@@ -60,33 +60,33 @@ describe Keen do
   describe "forwardable" do
     before do
       @default_client = double("client")
-      Keen.stub(:default_client).and_return(@default_client)
+      allow(Keen).to receive(:default_client).and_return(@default_client)
     end
 
     [:project_id, :write_key, :read_key, :api_url, :proxy_url, :proxy_type].each do |_method|
       it "should forward the #{_method} method" do
-        @default_client.should_receive(_method)
+        expect(@default_client).to receive(_method)
         Keen.send(_method)
       end
     end
 
     [:project_id, :write_key, :read_key, :master_key, :api_url].each do |_method|
       it "should forward the #{_method} method" do
-        @default_client.should_receive(_method)
+        expect(@default_client).to receive(_method)
         Keen.send(_method)
       end
     end
 
     [:project_id=, :write_key=, :read_key=, :master_key=, :api_url=].each do |_method|
       it "should forward the #{_method} method" do
-        @default_client.should_receive(_method).with("12345")
+        expect(@default_client).to receive(_method).with("12345")
         Keen.send(_method, "12345")
       end
     end
 
     [:publish, :publish_async, :publish_batch, :publish_batch_async].each do |_method|
       it "should forward the #{_method} method" do
-        @default_client.should_receive(_method).with("users", {})
+        expect(@default_client).to receive(_method).with("users", {})
         Keen.send(_method, "users", {})
       end
     end
@@ -95,7 +95,7 @@ describe Keen do
     # any new methods have a corresponding delegator
     Keen::Client::QueryingMethods.instance_methods.each do |_method|
       it "should forward the #{_method} query method" do
-        @default_client.should_receive(_method).with("users", {})
+        expect(@default_client).to receive(_method).with("users", {})
         Keen.send(_method, "users", {})
       end
     end
@@ -103,7 +103,7 @@ describe Keen do
 
   describe "logger" do
     it "should be set to info" do
-      Keen.logger.level.should == Logger::INFO
+      expect(Keen.logger.level).to eq(Logger::INFO)
     end
   end
 end

--- a/spec/keen/scoped_key_old_spec.rb
+++ b/spec/keen/scoped_key_old_spec.rb
@@ -14,11 +14,11 @@ describe Keen::ScopedKey do
 
   describe "constructor" do
     it "should retain the api_key" do
-      new_scoped_key.api_key.should == api_key
+      expect(new_scoped_key.api_key).to eq(api_key)
     end
 
     it "should retain the data" do
-      new_scoped_key.data.should == data
+      expect(new_scoped_key.data).to eq(data)
     end
   end
 
@@ -26,19 +26,19 @@ describe Keen::ScopedKey do
     it "should encrypt and hex encode the data using the api key" do
       encrypted_str = new_scoped_key.encrypt!
       other_api_key = Keen::ScopedKey.decrypt!(api_key, encrypted_str)
-      other_api_key.data.should == data
+      expect(other_api_key.data).to eq(data)
     end
 
     describe "when an IV is not provided" do
       it "should not produce the same encrypted key text" do
-        new_scoped_key.encrypt!.should_not == (new_scoped_key.encrypt!)
+        expect(new_scoped_key.encrypt!).to_not eq(new_scoped_key.encrypt!)
       end
     end
 
     describe "when an IV is provided" do
       it "should produce the same encrypted key text for a " do
         iv = "\0" * 16
-        new_scoped_key.encrypt!(iv).should == (new_scoped_key.encrypt!(iv))
+        expect(new_scoped_key.encrypt!(iv)).to eq(new_scoped_key.encrypt!(iv))
       end
 
       it "should raise error when an invalid IV is supplied" do

--- a/spec/keen/scoped_key_spec.rb
+++ b/spec/keen/scoped_key_spec.rb
@@ -14,11 +14,11 @@ describe Keen::ScopedKey do
 
   describe "constructor" do
     it "should retain the api_key" do
-      new_scoped_key.api_key.should == api_key
+      expect(new_scoped_key.api_key).to eq(api_key)
     end
 
     it "should retain the data" do
-      new_scoped_key.data.should == data
+      expect(new_scoped_key.data).to eq(data)
     end
   end
 
@@ -26,19 +26,19 @@ describe Keen::ScopedKey do
     it "should encrypt and hex encode the data using the api key" do
       encrypted_str = new_scoped_key.encrypt!
       other_api_key = Keen::ScopedKey.decrypt!(api_key, encrypted_str)
-      other_api_key.data.should == data
+      expect(other_api_key.data).to eq(data)
     end
 
     describe "when an IV is not provided" do
       it "should not produce the same encrypted key text" do
-        new_scoped_key.encrypt!.should_not == (new_scoped_key.encrypt!)
+        expect(new_scoped_key.encrypt!).to_not eq(new_scoped_key.encrypt!)
       end
     end
 
     describe "when an IV is provided" do
       it "should produce the same encrypted key text for a " do
         iv = "\0" * 16
-        new_scoped_key.encrypt!(iv).should == (new_scoped_key.encrypt!(iv))
+        expect(new_scoped_key.encrypt!(iv)).to eq(new_scoped_key.encrypt!(iv))
       end
 
       it "should raise error when an invalid IV is supplied" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ module Keen::SpecHelpers
     stub_keen_request(:delete, url, status, "")
   end
 
-  def expect_keen_request(method, url, body, sync_or_async_ua, read_or_write_key)
+  def expect_keen_request(method, url, body, sync_or_async_ua, read_or_write_key, extra_headers={})
     user_agent = "keen-gem, v#{Keen::VERSION}, #{sync_or_async_ua}"
     user_agent += ", #{RUBY_VERSION}, #{RUBY_PLATFORM}, #{RUBY_PATCHLEVEL}"
     if defined?(RUBY_ENGINE)
@@ -43,22 +43,24 @@ module Keen::SpecHelpers
                 "Authorization" => read_or_write_key,
                 "Keen-Sdk" => "ruby-#{Keen::VERSION}" }
 
-    WebMock.should have_requested(method, url).with(
+    headers = headers.merge(extra_headers) if not extra_headers.empty?
+
+    expect(WebMock).to have_requested(method, url).with(
       :body => body,
       :headers => headers)
 
   end
 
-  def expect_keen_get(url, sync_or_async_ua, read_key)
-    expect_keen_request(:get, url, "", sync_or_async_ua, read_key)
+  def expect_keen_get(url, sync_or_async_ua, read_key, extra_headers={})
+    expect_keen_request(:get, url, "", sync_or_async_ua, read_key, extra_headers)
   end
 
-  def expect_keen_post(url, event_properties, sync_or_async_ua, write_key)
-    expect_keen_request(:post, url, MultiJson.encode(event_properties), sync_or_async_ua, write_key)
+  def expect_keen_post(url, event_properties, sync_or_async_ua, write_key, extra_headers={})
+    expect_keen_request(:post, url, MultiJson.encode(event_properties), sync_or_async_ua, write_key, extra_headers)
   end
 
-  def expect_keen_delete(url, sync_or_async_ua, master_key)
-    expect_keen_request(:delete, url, "", sync_or_async_ua, master_key)
+  def expect_keen_delete(url, sync_or_async_ua, master_key, extra_headers={})
+    expect_keen_request(:delete, url, "", sync_or_async_ua, master_key, extra_headers)
   end
 
   def api_event_collection_resource_url(base_url, collection)
@@ -77,4 +79,3 @@ RSpec.configure do |config|
   config.tty        = true
   config.formatter  = :progress # :progress, :documentation, :html, :textmate
 end
-


### PR DESCRIPTION
- Allow the `:headers` option when sending a request
- Adds a test for optional headers
- Clean up deprecated test syntax (remove `should` in favor of `expect`)
- Suppress `stdout` during test runs to clean up test output
- Bump the version number and add to the changelog.