### PR TITLE
Update gem to 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,8 @@ This is helpful for tracking email clickthroughs. See the [redirect documentatio
 
 #### Generating scoped keys
 
+Note, Scoped Keys are now *deprecated* in favor of [access keys](https://keen.io/docs/api/#access-keys?s=gh-gem).
+
 A [scoped key](https://keen.io/docs/security/#scoped-key?s=gh-gem) is a string, generated with your API Key, that represents some encrypted authentication and query options.
 Use them to control what data queries have access to.
 
@@ -368,6 +370,34 @@ scoped_key = Keen::ScopedKey.new("my-api-key", { "filters" => [{
 ```
 
 You can use the scoped key created in Ruby for API requests from any client. Scoped keys are commonly used in JavaScript, where credentials are visible and need to be protected.
+
+#### Access Keys
+
+You can use access keys to restrict the functionality of a key you use with the Keen API. Access keys can also enrich events that you send.
+
+[Read up](https://keen.io/docs/api/#access-keys?s=gh-gem) on the full key body options.
+
+Create a key that automatically adds information to each event published with that key:
+
+``` ruby
+key_body = {
+  "name" => "autofill foo",
+  "is_active" => true,
+  "permitted" => ["writes"],
+  "options" => {
+    "writes" => {
+      "autofill": {
+        "foo": "bar"
+      }
+    }
+  }
+}
+
+new_key = client.access_keys.create(key_body)
+autofill_write_key = new_key["key"]
+```
+
+You can `revoke` and `unrevoke` keys to disable or enable access. `all` will return all current keys for the project, while `get("key-value-here")` will return info for a single key. You can also `update` and `delete` keys.
 
 ### Additional options
 
@@ -416,6 +446,11 @@ It's not just us humans that browse the web. Spiders, crawlers, and bots share t
 If you want some bot protection, check out the [Voight-Kampff](https://github.com/biola/Voight-Kampff) gem. Use the gem's `request.bot?` method to detect bots and avoid logging events.
 
 ### Changelog
+
+##### 1.1.0
++ Add support for access keys
++ Move saved queries into the Keen namespace
++ Deprecate scoped keys in favor of access keys
 
 ##### 1.0.0
 + Remove support for ruby 1.9.3

--- a/lib/keen.rb
+++ b/lib/keen.rb
@@ -1,6 +1,7 @@
 require 'logger'
 require 'forwardable'
 
+require 'keen/access_keys'
 require 'keen/client'
 require 'keen/saved_queries'
 require 'keen/scoped_key'
@@ -53,7 +54,8 @@ module Keen
                    :project_info,
                    :query_url,
                    :query,
-                   :saved_queries
+                   :saved_queries,
+                   :access_keys
 
     attr_writer :logger
 

--- a/lib/keen/access_keys.rb
+++ b/lib/keen/access_keys.rb
@@ -1,0 +1,93 @@
+require 'multi_json'
+
+module Keen
+  class AccessKeys
+    def initialize(client)
+      @client = client
+    end
+
+    def get(key)
+      client.ensure_master_key!
+      path = "/#{key}"
+
+      response = access_keys_get(client.master_key, path)
+      client.process_response(response.code.to_i, response.body)
+    end
+
+    def all()
+      client.ensure_master_key!
+
+      response = access_keys_get(client.master_key)
+      client.process_response(response.code.to_i, response.body)
+    end
+
+    # For information on the format of the key_body, see
+    # https://keen.io/docs/api/#access-keys
+    def create(key_body)
+      client.ensure_master_key!
+
+      path = ""
+      response = access_keys_post(client.master_key, path, key_body)
+      client.process_response(response.code.to_i, response.body)
+    end
+
+    def update(key, key_body)
+      client.ensure_master_key!
+
+      path = "/#{key}"
+      response = access_keys_post(client.master_key, path, key_body)
+      client.process_response(response.code.to_i, response.body)
+    end
+
+    def revoke(key)
+      client.ensure_master_key!
+
+      path = "/#{key}/revoke"
+      response = access_keys_post(client.master_key, path)
+      client.process_response(response.code.to_i, response.body)
+    end
+
+    def unrevoke(key)
+      client.ensure_master_key!
+
+      path = "/#{key}/unrevoke"
+      response = access_keys_post(client.master_key, path)
+      client.process_response(response.code.to_i, response.body)
+    end
+
+    def delete(key)
+      client.ensure_master_key!
+
+      response = Keen::HTTP::Sync.new(client.api_url, client.proxy_url, client.read_timeout, client.open_timeout).delete(
+        path: access_keys_base_url + "/#{key}",
+        headers: client.api_headers(client.master_key, "sync")
+      )
+
+      client.process_response(response.code.to_i, response.body)
+    end
+
+    def access_keys_base_url
+      client.ensure_project_id!
+      "/#{client.api_version}/projects/#{client.project_id}/keys"
+    end
+
+    private
+
+    attr_reader :client
+
+    def access_keys_get(api_key, path = "")
+      Keen::HTTP::Sync.new(client.api_url, client.proxy_url, client.read_timeout, client.open_timeout).get(
+        path: access_keys_base_url + path,
+        headers: client.api_headers(api_key, "sync")
+      )
+    end
+
+    def access_keys_post(api_key, path = "", body = "")
+      Keen::HTTP::Sync.new(client.api_url, client.proxy_url, client.read_timeout, client.open_timeout).post(
+        path: access_keys_base_url + path,
+        headers: client.api_headers(api_key, "sync"),
+        body: MultiJson.dump(body)
+      )
+    end
+  end
+end

--- a/lib/keen/client.rb
+++ b/lib/keen/client.rb
@@ -61,6 +61,10 @@ module Keen
       @saved_queries ||= SavedQueries.new(self)
     end
 
+    def access_keys
+      @access_keys ||= AccessKeys.new(self)
+    end
+
     def process_response(status_code, response_body)
       case status_code.to_i
       when 200..201

--- a/lib/keen/scoped_key.rb
+++ b/lib/keen/scoped_key.rb
@@ -3,6 +3,7 @@ require 'keen/aes_helper'
 require 'keen/aes_helper_old'
 
 module Keen
+  # <b>DEPRECATED:</b> Please use <tt>access keys</tt> instead.
   class ScopedKey
 
     attr_accessor :api_key
@@ -26,6 +27,8 @@ module Keen
     end
 
     def encrypt!(iv = nil)
+      warn "[DEPRECATION] Scoped keys are deprecated. Please use `access_keys` instead."
+
       json_str = MultiJson.dump(self.data)
       if self.api_key.length == 64
         Keen::AESHelper.aes256_encrypt(self.api_key, json_str, iv)

--- a/lib/keen/version.rb
+++ b/lib/keen/version.rb
@@ -1,3 +1,3 @@
 module Keen
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/spec/integration/access_keys_spec.rb
+++ b/spec/integration/access_keys_spec.rb
@@ -1,0 +1,70 @@
+require File.expand_path("../spec_helper", __FILE__)
+
+describe "Access Keys" do
+  let(:project_id) { ENV["KEEN_PROJECT_ID"] }
+  let(:master_key) { ENV["KEEN_MASTER_KEY"] }
+  let(:client) { Keen::Client.new(project_id: project_id, master_key: master_key) }
+
+  describe "#all" do
+    it "gets all access keys" do
+      expect(client.access_keys.all).to be_instance_of(Array)
+    end
+  end
+
+  describe "#create" do
+    it "creates a key" do
+      key_body = {
+        "name" => "integration test key",
+        "is_active" => true,
+        "permitted" => ["queries"],
+        "options" => {}
+      }
+
+      create_result = client.access_keys.create(key_body)
+      expect(create_result["name"]).to eq(key_body["name"])
+    end
+  end
+
+  describe "#get" do
+    it "gets a single access key" do
+      all_keys = client.access_keys.all
+
+      access_key = client.access_keys.get(all_keys.first["key"])
+
+      expect(access_key["name"]).to eq(all_keys.first["name"])
+    end
+  end
+
+  describe "#revoke" do
+    it "sets the is_active to false" do
+      all_keys = client.access_keys.all
+      key = all_keys.first["key"]
+
+      client.access_keys.revoke(key)
+      new_key = client.access_keys.get(key)
+      expect(new_key["is_active"]).to be_falsey
+    end
+  end
+
+  describe "#unrevoke" do
+    it "sets the is_active to true" do
+      all_keys = client.access_keys.all
+      key = all_keys.first["key"]
+
+      client.access_keys.unrevoke(key)
+      new_key = client.access_keys.get(key)
+      expect(new_key["is_active"]).to be_truthy
+    end
+  end
+
+  describe "#delete" do
+    it "deletes a key" do
+      all_keys = client.access_keys.all
+      key = all_keys.first["key"]
+
+      client.access_keys.delete(key)
+      all_keys = client.access_keys.all
+      expect(all_keys).to eq([])
+    end
+  end
+end

--- a/spec/keen/access_keys_spec.rb
+++ b/spec/keen/access_keys_spec.rb
@@ -1,0 +1,113 @@
+require File.expand_path("../spec_helper", __FILE__)
+
+describe Keen do
+  let(:client) do
+    Keen::Client.new(
+      project_id: "12341234",
+      master_key: "abcdef",
+      api_url: "https://notreal.keen.io"
+    )
+  end
+
+  describe "#access_keys" do
+    describe "#all" do
+
+      it "returns all access keys" do
+        all_access_keys = [
+          key_object()
+        ]
+
+        stub_keen_get(access_keys_endpoint, 200, all_access_keys)
+
+        all_access_keys_response = client.access_keys.all
+
+        expect(all_access_keys_response).to eq(all_access_keys)
+      end
+    end
+
+    describe "#get" do
+      it "returns a specific access key given a key" do
+        key = key_object()
+
+        stub_keen_get(
+          access_keys_endpoint + "/#{key["key"]}",
+          200,
+          key
+        )
+
+        access_key_response = client.access_keys.get(key["key"])
+
+        expect(access_key_response).to eq(key)
+      end
+		end
+
+    describe "#create" do
+      it "returns the created saved query when creation is successful" do
+        key = key_object()
+
+        stub_keen_post(
+          access_keys_endpoint, 201, key
+        )
+
+        access_keys_response = client.access_keys.create(key)
+
+        expect(access_keys_response).to eq(key)
+      end
+    end
+
+    describe "#update" do
+      it "returns the updated access key when update is successful" do
+        key = key_object()
+
+        stub_keen_post(
+          access_keys_endpoint + "/#{key["key"]}", 200, key
+        )
+
+        access_keys_response = client.access_keys.update(key["key"], key)
+
+        expect(access_keys_response).to eq(key)
+      end
+    end
+
+    describe "#delete" do
+      it "returns true with deletion is successful" do
+        key = "asdf1234"
+
+        stub_keen_delete(
+          access_keys_endpoint + "/#{key}", 204
+        )
+
+        access_keys_response = client.access_keys.delete(key)
+
+        expect(access_keys_response).to eq(true)
+      end
+    end
+  end
+
+  def access_keys_endpoint
+    client.api_url + "/#{client.api_version}/projects/#{client.project_id}/keys"
+  end
+
+  def key_object(name = "Test Access Key")
+    {
+      "key" => "SDKFJSDKFJSDKFJSDKFJDSK",
+      "name" => name,
+      "is_active" => true,
+      "permitted" => ["queries", "cached_queries"],
+      "options" => {
+        "queries" => {
+          "filters" => [
+            {
+              "property_name" => "customer.id",
+              "operator" => "eq", 
+              "property_value" => "asdf12345z"
+            }
+          ]
+        },
+        "cached_queries" => {
+          "allowed" => ["my_cached_query"]
+        }
+      }
+    }
+  end
+end


### PR DESCRIPTION
- Deprecates scoped keys
- Adds `access_keys`
- Move saved queries into Keen namespace
- Update integration tests to use timeframes