### PR TITLE
Implement method to delete properties

### DIFF
--- a/lib/keen.rb
+++ b/lib/keen.rb
@@ -51,6 +51,7 @@ module Keen
 
     def_delegators :default_client,
                    :delete,
+                   :delete_property,
                    :event_collections,
                    :project_info,
                    :query_url,

--- a/lib/keen/client.rb
+++ b/lib/keen/client.rb
@@ -106,9 +106,20 @@ module Keen
     private
 
     def api_event_collection_resource_path(event_collection)
-      encoded_collection_name = Addressable::URI.encode_component(event_collection.to_s)
-      encoded_collection_name.gsub! '/', '%2F'
+      encoded_collection_name = encode_parameter(event_collection)
       "/#{api_version}/projects/#{project_id}/events/#{encoded_collection_name}"
+    end
+
+    def api_event_collection_property_resource_path(event_collection, property)
+      encoded_collection_name = encode_parameter(event_collection)
+      encoded_property_name = encode_parameter(property)
+      "/#{api_version}/projects/#{project_id}/events/#{encoded_collection_name}/properties/#{encoded_property_name}"
+    end
+
+    def encode_parameter(parameter)
+      encoded_parameter = Addressable::URI.encode_component(parameter.to_s)
+      encoded_parameter.gsub! '/', '%2F'
+      encoded_parameter
     end
 
     def preprocess_params(params)

--- a/lib/keen/client/maintenance_methods.rb
+++ b/lib/keen/client/maintenance_methods.rb
@@ -27,6 +27,28 @@ module Keen
         process_response(response.code, response_body)
       end
 
+      # Runs a delete a property query.
+      # See detailed documentation here:
+      # https://keen.io/docs/maintenance/#deleting-a-property
+      #
+      # @param event_collection
+      # @param property
+      def delete_property(event_collection, property)
+        ensure_project_id!
+        ensure_master_key!
+
+        begin
+          response = http_sync.delete(
+              :path => api_event_collection_property_resource_path(event_collection, property),
+              :headers => api_headers(self.master_key, "sync"))
+        rescue Exception => http_error
+          raise HttpError.new("Couldn't perform delete property #{property} of #{event_collection} on Keen IO: #{http_error.message}", http_error)
+        end
+
+        response_body = response.body ? response.body.chomp : ''
+        process_response(response.code, response_body)
+      end
+
       # Return list of collections for the configured project
       # See detailed documentation here:
       # https://keen.io/docs/api/reference/#event-resource

--- a/spec/keen/client/maintenance_methods_spec.rb
+++ b/spec/keen/client/maintenance_methods_spec.rb
@@ -14,6 +14,10 @@ describe Keen::Client do
     "#{api_url}/#{api_version}/projects/#{project_id}/events/#{event_collection}#{filter_params ? "?filters=#{CGI.escape(MultiJson.encode(filter_params[:filters]))}" : ""}"
   end
 
+  def delete_property_url(event_collection, property)
+    "#{api_url}/#{api_version}/projects/#{project_id}/events/#{event_collection}/properties/#{property}"
+  end
+
   describe '#delete' do
     let(:event_collection) { :foodstuffs }
 
@@ -33,6 +37,18 @@ describe Keen::Client do
       url = delete_url(event_collection, filters)
       stub_keen_delete(url, 204)
       client.delete(event_collection, filters)
+      expect_keen_delete(url, "sync", master_key)
+    end
+  end
+
+  describe '#delete_property' do
+    let(:event_collection) { :foodstuffs }
+    let(:property) { :type }
+
+    it 'should delete a property' do
+      url = delete_property_url(event_collection, property)
+      stub_keen_delete(url, 204)
+      expect(client.delete_property(event_collection, property)).to be true
       expect_keen_delete(url, "sync", master_key)
     end
   end


### PR DESCRIPTION
This implements the API method to delete properties from collections as documented here https://keen.io/docs/maintenance/#deleting-a-property