### PR TITLE
Force TLS peer verification when base URL scheme is HTTPS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: ruby
 bundler_args: --without development
 
 rvm:
-  - 2.1.10
-  - 2.2.7
-  - 2.4.1
+  - 2.4.10
+  - 2.6.6
+  - 2.7.1
 
 env:
   matrix:


### PR DESCRIPTION
Related to [this issue](https://github.com/igrigorik/em-http-request/issues/339) on the `em-http-request` gem.

Currently, every request sent to Keen shows this warning :
```
[WARNING; em-http-request] TLS hostname validation is disabled (use 'tls: {verify_peer: true}'), see CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details
```

To fix this, this commit checks the base URL's scheme and forces the TLS peer verification if it's HTTPS.

I recommend to release a new version when this is merged, for security reasons.
Thanks in advance.